### PR TITLE
Support for reusing value from StringTable::getCode()

### DIFF
--- a/include/geodesk/feature/FeatureBase.h
+++ b/include/geodesk/feature/FeatureBase.h
@@ -231,6 +231,14 @@ public:
         return tags.tagValue(val, store_.ptr()->strings());
     }
 
+    TagValue getTagWithCode(const std::string_view& key, int code) const noexcept
+    {
+        if(isAnonymousNode()) return {};     // empty string
+        const TagTablePtr tags = feature_.ptr.tags();
+        const TagBits val = tags.getKeyValueWithCode(key.data(), key.size(), code, store_.ptr()->strings());
+        return tags.tagValue(val, store_.ptr()->strings());
+    }
+
     [[nodiscard]] Tags tags() const noexcept
     {
         return Tags(store(), ptr());

--- a/include/geodesk/feature/FeatureStore.h
+++ b/include/geodesk/feature/FeatureStore.h
@@ -45,13 +45,13 @@ public:
     {
         BlobStore::open(fileName, 0);   // TODO: open mode
     }
-    
+
     void addref()  { ++refcount_;  }
     void release() { if (--refcount_ == 0) delete this;  }
     size_t refcount() const { return refcount_; }
 
     DataPtr tileIndex() const
-    { 
+    {
         return getPointer(TILE_INDEX_PTR_OFS);
     }
 
@@ -62,10 +62,10 @@ public:
     const MatcherHolder* getMatcher(const char* query);
 
     const MatcherHolder* borrowAllMatcher() const { return &allMatcher_; }
-    const MatcherHolder* getAllMatcher() 
-    { 
+    const MatcherHolder* getAllMatcher()
+    {
         allMatcher_.addref();
-        return &allMatcher_; 
+        return &allMatcher_;
     }
     bool isAllMatcher(const MatcherHolder* matcher) const
     {
@@ -90,7 +90,7 @@ protected:
     }
 
 private:
-	static const uint32_t SubtypeMagic = 0x1CE50D6E;
+  static const uint32_t SubtypeMagic = 0x1CE50D6E;
 
     static const uint32_t ZOOM_LEVELS_OFS = 40;
     static const uint32_t TILE_INDEX_PTR_OFS = 44;
@@ -103,15 +103,15 @@ private:
 
     static std::unordered_map<std::string, FeatureStore*>& getOpenStores();
     static std::mutex& getOpenStoresMutex();
-    
-    size_t refcount_;
+
+    std::atomic_size_t refcount_;
     StringTable strings_;
     IndexedKeyMap keysToCategories_;
     MatcherCompiler matchers_;
     MatcherHolder allMatcher_;
     #ifdef GEODESK_PYTHON
     PyObject* emptyTags_;
-    PyFeatures* emptyFeatures_;       
+    PyFeatures* emptyFeatures_;
         // TODO: Need to keep this here due to #46, because a feature set
         // needs a valid reference to a FeatureStore (even if empty)
         // Not ideal, should have global singleton instead of per-store,

--- a/include/geodesk/feature/TagTablePtr.h
+++ b/include/geodesk/feature/TagTablePtr.h
@@ -67,6 +67,8 @@ public:
 	uint32_t count() const;
 	TagBits getKeyValue(const char* key, size_t len,
 		const StringTable& strings) const;
+	TagBits getKeyValueWithCode(const char* key, size_t len, int code,
+		const StringTable& strings) const;
 	TagBits getKeyValue(const std::string_view& sv, const StringTable& strings) const
 	{
 		return getKeyValue(sv.data(), sv.size(), strings);

--- a/include/geodesk/match/Matcher.h
+++ b/include/geodesk/match/Matcher.h
@@ -24,7 +24,7 @@ typedef const Matcher* (*RoleMatcherMethod)(const RoleMatcher*, FeaturePtr);
 // a RoleMatcher and their associated resources (pointers to other MatcherHolder
 // objects, Regex patterns, string constants, numeric constants)
 // Resources are placed ahead of the MatcherHolder, so we need to take care when
-// deallocating, because the pointer may not point to the actual start of the 
+// deallocating, because the pointer may not point to the actual start of the
 // heap object.
 //
 // <resources>              (variable length)
@@ -50,7 +50,7 @@ public:
     }
 
     FeatureStore* store() const { return store_; }
-    
+
 private:
     MatcherMethod function_;
     FeatureStore* store_;           // not refcounted
@@ -86,9 +86,9 @@ public:
     MatcherHolder(FeatureTypes types, uint32_t keyMask, uint32_t keyMin);
 
     static const MatcherHolder* createMatchAll(FeatureTypes types);
-    static const MatcherHolder* createMatchKey(FeatureTypes types, 
+    static const MatcherHolder* createMatchKey(FeatureTypes types,
         uint32_t indexBits, int keyCode, int codeNo);
-    static const MatcherHolder* createMatchKeyValue(FeatureTypes types, 
+    static const MatcherHolder* createMatchKeyValue(FeatureTypes types,
         uint32_t indexBits, int keyCode, int valueCode);
 
     /**
@@ -118,7 +118,7 @@ private:
     static bool matchAllMethod(const Matcher*, FeaturePtr);
     static uint8_t* alloc(size_t size) { return new uint8_t[size]; };
 
-    mutable uint32_t refcount_;
+    mutable std::atomic_uint_fast32_t refcount_;
     FeatureTypes acceptedTypes_;
     uint32_t resourcesLength_;
     uint32_t referencedMatcherHoldersCount_;

--- a/src/feature/TagTablePtr.cpp
+++ b/src/feature/TagTablePtr.cpp
@@ -44,6 +44,12 @@ int64_t TagTablePtr::getKeyValue(const char* key, size_t len,
 	const StringTable& strings) const
 {
 	int code = strings.getCode(key, len);
+	return getKeyValueWithCode(key, len, code, strings);
+}
+
+int64_t TagTablePtr::getKeyValueWithCode(const char* key, size_t len, int code,
+  const StringTable& strings) const
+{
 	if (code >= 0 && code <= TagValues::MAX_COMMON_KEY)
 	{
 		return getGlobalKeyValue(code);

--- a/src/query/Query.cpp
+++ b/src/query/Query.cpp
@@ -28,7 +28,7 @@ Query::Query(FeatureStore* store, const Box& box, FeatureTypes types,
     // Don't add refcount to store, wrapper object is responsible for liveness
     // of all resources
     store->addref();        // TODO: should we add a refcount to the store here?
-                            // maybe it makes more sense for PyQuery to hold a ref 
+                            // maybe it makes more sense for PyQuery to hold a ref
                             // to its PyFeatures; this way, store, matcher and filter
                             // are guaranteed to be kept alive for duration of the
                             // query's lifetime
@@ -104,7 +104,7 @@ const QueryResults* Query::take()
 
     // Turn the circular list into a simple list ending with EMPTY
     QueryResults* first = res->next;
-    res->next = QueryResults::EMPTY;
+    if(res != QueryResults::EMPTY) res->next = QueryResults::EMPTY;
     return first;
 }
 
@@ -118,7 +118,7 @@ void Query::requestTiles()
             allTilesRequested_ = true;
             break;
         }
-        TileQueryTask task(this, 
+        TileQueryTask task(this,
             (tileIndexWalker_.currentTip() << 8) |
              tileIndexWalker_.northwestFlags());
         // boost::asio::post(store_->executor(), task);
@@ -152,7 +152,7 @@ void Query::requestTiles()
         pendingTiles_++;
         submitCount--;
     }
-    
+
 }
 
 FeaturePtr Query::next()


### PR DESCRIPTION
Hello,

Not sure if you're accepting pull requests, so feel free to close this if not.  

At [styluslabs/geodesk-tiles](https://github.com/styluslabs/geodesk-tiles) I'm working on building vector tiles on demand from a GeoDesk GOL for use with [Ascend Maps](https://github.com/styluslabs/maps).  It is working well and I plan to set up a server soon.

Repeated calls to `StringTable::getCode()` were taking up a significant amount of time, so I added the change here to allow reusing the string code.

Would you be interested in additional pull requests to cleanup whitespace (tabs and spaces are mixed throughout the source) and to eliminate compile warnings with gcc -Wall?

Best,
Matt