### PR TITLE
Fix discarding file-backed mappings on Windows

### DIFF
--- a/src/clarisma/io/MappedFile_windows.cxx
+++ b/src/clarisma/io/MappedFile_windows.cxx
@@ -60,7 +60,9 @@ void MappedFile::prefetch(void* address, uint64_t length)
 
 void MappedFile::discard(void* address, uint64_t length)
 {
-    DiscardVirtualMemory(address, length);
+    // Calling VirtualUnlock on unlocked mapped pages removes them from the
+    // working set; FALSE with ERROR_NOT_LOCKED is the expected result.
+    (void)VirtualUnlock(address, static_cast<SIZE_T>(length));
 }
 
 } // namespace clarisma


### PR DESCRIPTION
This is one of two PRs to fix the https://github.com/clarisma/geodesk-gol/issues/55 issue.

`MappedFile::discard()` currently uses `DiscardVirtualMemory()`, which silently fails with `ERROR_USER_MAPPED_FILE` for file-backed mappings.

This replaces it with `VirtualUnlock()`. The API is a bit odd, but documented. For ordinary unlocked pages, it removes them from the process working set, returns FALSE, and sets ERROR_NOT_LOCKED.

[VirtualUnlock function (memoryapi.h) - Win32 apps | Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualunlock#remarks)